### PR TITLE
Rearrange a couple lines of embedded py code so 'env' can be handed to find_templates(str, env)

### DIFF
--- a/prefab.el
+++ b/prefab.el
@@ -192,7 +192,7 @@ import os.path
 ctx = %s
 envvars = ctx.get('cookiecutter', {}).get('_jinja2_env_vars', {})
 env = StrictEnvironment(context=ctx, keep_trailing_newline=True, **envvars)
-template_dir = find_template('%s')
+template_dir = find_template('%s', env)
 dirname = os.path.split(template_dir)[1]
 output_dir = '%s'
 

--- a/prefab.el
+++ b/prefab.el
@@ -190,10 +190,10 @@ from cookiecutter.environment import StrictEnvironment
 import os.path
 
 ctx = %s
-template_dir = find_template('%s')
-dirname = os.path.split(template_dir)[1]
 envvars = ctx.get('cookiecutter', {}).get('_jinja2_env_vars', {})
 env = StrictEnvironment(context=ctx, keep_trailing_newline=True, **envvars)
+template_dir = find_template('%s')
+dirname = os.path.split(template_dir)[1]
 output_dir = '%s'
 
 name_tmpl = env.from_string(dirname)


### PR DESCRIPTION
Cookiecutter.find.find_template() requires 2 positional parameters. 1) a path, and 2) a cookiecutter.environment.StrictEnvironmentEnvironment object. The env was not being provided to find_template() causing an error in (prefab--cookiecutter-created-dir). I rearranged a block of the embedded python so we can hand the env object to find_templates. 

